### PR TITLE
Fix logging

### DIFF
--- a/mstp-lib/internal/stp.cpp
+++ b/mstp-lib/internal/stp.cpp
@@ -470,6 +470,7 @@ void STP_EnableLogging (STP_BRIDGE* bridge, bool enable)
 {
 	#if STP_USE_LOG
 		bridge->loggingEnabled = enable;
+		bridge->logLineStarting = true;
 	#endif
 }
 


### PR DESCRIPTION
If `STP_BRIDGE.logLineStarting` is not set to `true` when logging is enabled, `WriteChar` doesn't initialize properly, and the assert at stp_log.cpp line 85 trips as a result.