### PR TITLE
Allow choosing learning and forwarding state during StopBridge

### DIFF
--- a/mstp-lib/internal/stp.cpp
+++ b/mstp-lib/internal/stp.cpp
@@ -192,7 +192,7 @@ void STP_StartBridge (STP_BRIDGE* bridge, unsigned int timestamp)
 
 // ============================================================================
 
-void STP_StopBridge (STP_BRIDGE* bridge, unsigned int timestamp)
+void STP_StopBridge (STP_BRIDGE* bridge, unsigned int timestamp, bool fallbackLearning, bool fallbackForwarding)
 {
 	assert (bridge->started);
 
@@ -207,14 +207,14 @@ void STP_StopBridge (STP_BRIDGE* bridge, unsigned int timestamp)
 
 			if (!tree->learning)
 			{
-				bridge->callbacks.enableLearning(bridge, pi, ti, true, timestamp);
-				tree->learning = true;
+				bridge->callbacks.enableLearning(bridge, pi, ti, fallbackLearning, timestamp);
+				tree->learning = fallbackLearning;
 			}
 
 			if (!tree->forwarding)
 			{
-				bridge->callbacks.enableForwarding(bridge, pi, ti, true, timestamp);
-				tree->forwarding = true;
+				bridge->callbacks.enableForwarding(bridge, pi, ti, fallbackForwarding, timestamp);
+				tree->forwarding = fallbackForwarding;
 			}
 		}
 	}
@@ -1399,4 +1399,3 @@ extern "C" unsigned int STP_GetTxCount (const struct STP_BRIDGE* bridge, unsigne
 {
 	return bridge->ports[portIndex]->txCount;
 }
-

--- a/mstp-lib/internal/stp.cpp
+++ b/mstp-lib/internal/stp.cpp
@@ -205,13 +205,13 @@ void STP_StopBridge (STP_BRIDGE* bridge, unsigned int timestamp, bool fallbackLe
 		{
 			PORT_TREE* tree = port->trees[ti];
 
-			if (!tree->learning)
+			if ((!tree->learning && fallbackLearning) || (tree->learning && !fallbackLearning))
 			{
 				bridge->callbacks.enableLearning(bridge, pi, ti, fallbackLearning, timestamp);
 				tree->learning = fallbackLearning;
 			}
 
-			if (!tree->forwarding)
+			if ((!tree->forwarding && fallbackForwarding) || (tree->forwarding && !fallbackForwarding))
 			{
 				bridge->callbacks.enableForwarding(bridge, pi, ti, fallbackForwarding, timestamp);
 				tree->forwarding = fallbackForwarding;

--- a/mstp-lib/stp.h
+++ b/mstp-lib/stp.h
@@ -116,7 +116,7 @@ struct STP_BRIDGE* STP_CreateBridge (unsigned int portCount,
 void STP_DestroyBridge (struct STP_BRIDGE* bridge);
 
 void STP_StartBridge (struct STP_BRIDGE* bridge, unsigned int timestamp);
-void STP_StopBridge (struct STP_BRIDGE* bridge, unsigned int timestamp);
+void STP_StopBridge (struct STP_BRIDGE* bridge, unsigned int timestamp, bool fallbackLearning, bool fallbackForwarding);
 bool STP_IsBridgeStarted (const struct STP_BRIDGE* bridge);
 
 void STP_EnableLogging (struct STP_BRIDGE* bridge, bool enable);


### PR DESCRIPTION
Hi,

In my system I must enforce, that during stopping the STP stack both forwarding and learning are disabled, as opposed to current implementation.

Since C disallows function overloading, I've added 2 parameters to the existing STP_StopBridge function.