### PR TITLE
Discard BPDUs received on AdminEdge ports to avoid root hijacking attacks

### DIFF
--- a/mstp-lib/internal/stp.cpp
+++ b/mstp-lib/internal/stp.cpp
@@ -395,7 +395,7 @@ void STP_OnBpduReceived (STP_BRIDGE* bridge, unsigned int portIndex, const unsig
 			PORT* port = bridge->ports[portIndex];
 			if (port->AdminEdge && !port->AutoEdge)
 			{
-				LOG (bridge, -1, -1, "{T}: BPDU received on Port {D} - discarding it since port is administratively forced to be an edge port.\r\n", timestamp, 1 + portIndex);
+				LOG (bridge, -1, -1, "{T}: Discarding BPDU since port is administratively forced to be an edge port.\r\n", timestamp, 1 + portIndex);
 				LOG (bridge, -1, -1, "------------------------------------\r\n");
 				FLUSH_LOG (bridge);
 				return;

--- a/mstp-lib/internal/stp.cpp
+++ b/mstp-lib/internal/stp.cpp
@@ -387,11 +387,11 @@ void STP_OnBpduReceived (STP_BRIDGE* bridge, unsigned int portIndex, const unsig
 			/* If the port is administratively forced to be an edge port,
 			   BPDUs received on that port should be discarded to avoid
 			   root hijacking attacks. An end terminal could send a fake BPDU
-			   with a lower bridge ID so that it becomes the root bridge of the
+			   with a lower root ID so that it becomes the root bridge of the
 			   network topology and, hence, traffic could be intercepted.
-			   The BPDU is discarded only when AdminEdge is true and AutoEdge is disabled.
-			   If AutoEdge is enabled, the library will process the BPDU so that
-			   automatic edge detection is still possible. */
+			   The BPDU is discarded only when AdminEdge is true and AutoEdge
+			   is disabled. If AutoEdge is enabled, the library will process
+			   the BPDU so that automatic edge detection is still possible. */
 			PORT* port = bridge->ports[portIndex];
 			if (port->AdminEdge && !port->AutoEdge)
 			{

--- a/mstp-lib/internal/stp.cpp
+++ b/mstp-lib/internal/stp.cpp
@@ -384,6 +384,23 @@ void STP_OnBpduReceived (STP_BRIDGE* bridge, unsigned int portIndex, const unsig
 		{
 			LOG (bridge, -1, -1, "{T}: BPDU received on Port {D}:\r\n", timestamp, 1 + portIndex);
 
+			/* If the port is administratively forced to be an edge port,
+			   BPDUs received on that port should be discarded to avoid
+			   root hijacking attacks. An end terminal could send a fake BPDU
+			   with a lower bridge ID so that it becomes the root bridge of the
+			   network topology and, hence, traffic could be intercepted.
+			   The BPDU is discarded only when AdminEdge is true and AutoEdge is disabled.
+			   If AutoEdge is enabled, the library will process the BPDU so that
+			   automatic edge detection is still possible. */
+			PORT* port = bridge->ports[portIndex];
+			if (port->AdminEdge && !port->AutoEdge)
+			{
+				LOG (bridge, -1, -1, "{T}: BPDU received on Port {D} - discarding it since port is administratively forced to be an edge port.\r\n", timestamp, 1 + portIndex);
+				LOG (bridge, -1, -1, "------------------------------------\r\n");
+				FLUSH_LOG (bridge);
+				return;
+			}
+
 			enum VALIDATED_BPDU_TYPE type = STP_GetValidatedBpduType (bridge->ForceProtocolVersion, bpdu, bpduSize);
 			switch (type)
 			{


### PR DESCRIPTION
Hello.

I'm not entirely sure if this should be directly addressed by the library or by any implementation that uses it.

Right now, if a port is administratively set/forced to be an edge port and a BPDU is received on that port, the BPDU is still processed. This can lead to root hijacking attacks (known vulnerability): an end terminal connected to that port could send a fake BPDU with a lower root ID so that a topology change is triggered, with that end client being considered as a legitimate bridge and, thus, being selected as the root bridge of the topology. In this case, network traffic would be intercepted by that client, also enabling DoS and broadcast-storm attacks. If the network administrator knows the topology, they can set any port as administratively edge since no bridges will be connected to that port, but malicious end terminals could be connected anyways.

My request is that BPDUs received on ports with the `AdminEdge` flag set to `true` are discarded, as a security measure to avoid the described vulnerability to be exploited. BPDUs would only be discarded if the `AutoEdge` flag is set to `false`, so that edge detection could still be possible if that's the desired behaviour.

Thanks.