### PR TITLE
Add restricted-role port accessors

### DIFF
--- a/mstp-lib/internal/stp.cpp
+++ b/mstp-lib/internal/stp.cpp
@@ -663,6 +663,31 @@ bool STP_GetPortAutoEdge (const struct STP_BRIDGE* bridge, unsigned int portInde
 
 // ============================================================================
 
+void STP_SetPortRestrictedRole (struct STP_BRIDGE* bridge, unsigned int portIndex, bool restrictedRole, unsigned int timestamp)
+{
+	LOG (bridge, portIndex, -1, "{T}: Setting Port {D} restrictedRole to {D}...\r\n", timestamp, 1 + portIndex, restrictedRole ? 1 : 0);
+
+	PORT* port = bridge->ports[portIndex];
+
+	if (port->restrictedRole != restrictedRole)
+	{
+		port->restrictedRole = restrictedRole;
+
+		if (bridge->started)
+			RecomputePrioritiesAndPortRoles (bridge, CIST_INDEX, timestamp);
+	}
+
+	LOG (bridge, -1, -1, "------------------------------------\r\n");
+	FLUSH_LOG (bridge);
+}
+
+bool STP_GetPortRestrictedRole (const struct STP_BRIDGE* bridge, unsigned int portIndex)
+{
+	return bridge->ports[portIndex]->restrictedRole;
+}
+
+// ============================================================================
+
 void STP_SetAdminPointToPointMAC (struct STP_BRIDGE* bridge, unsigned int portIndex, enum STP_ADMIN_P2P adminPointToPointMAC, unsigned int timestamp)
 {
 	const char* p2pString = STP_GetAdminP2PString (adminPointToPointMAC);
@@ -1399,4 +1424,3 @@ extern "C" unsigned int STP_GetTxCount (const struct STP_BRIDGE* bridge, unsigne
 {
 	return bridge->ports[portIndex]->txCount;
 }
-

--- a/mstp-lib/stp.h
+++ b/mstp-lib/stp.h
@@ -161,6 +161,10 @@ bool STP_GetPortAdminEdge (const struct STP_BRIDGE* bridge, unsigned int portInd
 void STP_SetPortAutoEdge (struct STP_BRIDGE* bridge, unsigned int portIndex, bool autoEdge, unsigned int timestamp);
 bool STP_GetPortAutoEdge (const struct STP_BRIDGE* bridge, unsigned int portIndex);
 
+// ieee8021MstpCistPortRestrictedRole / ieee8021MstpPortRestrictedRole
+void STP_SetPortRestrictedRole (struct STP_BRIDGE* bridge, unsigned int portIndex, bool restrictedRole, unsigned int timestamp);
+bool STP_GetPortRestrictedRole (const struct STP_BRIDGE* bridge, unsigned int portIndex);
+
 // ----------------------------------------------------------------------------
 
 // ieee8021BridgeBasePortAdminPointToPoint / dot1dStpPortAdminPointToPoint


### PR DESCRIPTION
Expose setters/getters for the MSTP restrictedRole port flag and recompute port roles when it changes on a running bridge.